### PR TITLE
Removal of navigation bar buttons

### DIFF
--- a/src/main/java/org/vaadin/example/MainLayout.java
+++ b/src/main/java/org/vaadin/example/MainLayout.java
@@ -64,28 +64,10 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
             getUI().ifPresent(ui -> ui.navigate(""));
         });
 
-        Button budgetButton = new Button("Budgets");
-        budgetButton.addClickListener(e -> budgetButton.getUI().ifPresent(ui -> ui.navigate(BudgetView.class)));
-
-        Button expenseButton = new Button("Expenses");
-        expenseButton.addClickListener(e -> expenseButton.getUI().ifPresent(ui -> ui.navigate(ExpenseView.class)));
-
-        Button incomeButton = new Button("Income");
-        incomeButton.addClickListener(e -> incomeButton.getUI().ifPresent(ui -> ui.navigate(IncomeView.class)));
-
-        Button goalButton = new Button("Goals");
-        goalButton.addClickListener(e -> goalButton.getUI().ifPresent(ui -> ui.navigate(FinancialGoalView.class)));
-
-        Button dashboardButton = new Button("Dashboard");
-        dashboardButton.addClickListener(e -> dashboardButton.getUI().ifPresent(ui -> ui.navigate(DashboardView.class)));
-
-        Button assetButton = new Button("Assets");
-        assetButton.addClickListener(e -> assetButton.getUI().ifPresent(ui -> ui.navigate(AssetView.class)));
 
 
 
-
-       HorizontalLayout header = new HorizontalLayout(logo, dashboardButton, budgetButton, expenseButton, incomeButton, assetButton, goalButton, logoutButton);
+       HorizontalLayout header = new HorizontalLayout(logo, logoutButton);
        header.expand(logo);
        header.setWidthFull();
        header.setAlignItems(Alignment.CENTER);


### PR DESCRIPTION
## Description

This PR changes the navigation bar; more specifically, it removes all the buttons apart from the sign-out button. This is done so that we have a cleaner UI and don't overload the page for the user. Also users can navigate using the side bar.

Closes #58 

### Screenshot

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3e36b05c-684b-4642-aede-c58f04bfe115">


## Type of Change

- [ ] Bug fix 
- [X] New/Update feature 
- [ ] New/Update Documentation


