### PR TITLE
Cashflow Forecasting Missing Link

### DIFF
--- a/src/main/java/org/vaadin/application/MainLayout.java
+++ b/src/main/java/org/vaadin/application/MainLayout.java
@@ -8,6 +8,7 @@ import org.vaadin.application.views.ExpenseView;
 import org.vaadin.application.views.FinancialGoalView;
 import org.vaadin.application.views.IncomeView;
 import org.vaadin.application.views.LoginView;
+import org.vaadin.application.views.NetCashflowForecastView;
 import org.vaadin.application.views.RegistrationView;
 
 import com.vaadin.flow.component.applayout.AppLayout;
@@ -98,6 +99,7 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
     RouterLink goalLink = new RouterLink("Manage Goals", FinancialGoalView.class);
     RouterLink categoryLink = new RouterLink("Manage Categories", ExpenseCategoryView.class);
     RouterLink assetLink = new RouterLink("Manage Assets", AssetView.class);
+    RouterLink cashflowLink = new RouterLink("View Cashflow Forecast", NetCashflowForecastView.class);
 
     VerticalLayout drawerLayout = new VerticalLayout(
         dashboardLink,
@@ -106,7 +108,8 @@ public class MainLayout extends AppLayout implements BeforeEnterObserver {
         incomeLink,
         goalLink,
         categoryLink,
-        assetLink);
+        assetLink,
+        cashflowLink);
 
     drawerLayout.setAlignItems(Alignment.STRETCH);
     addToDrawer(drawerLayout);

--- a/src/main/java/org/vaadin/application/views/NetCashflowForecastView.java
+++ b/src/main/java/org/vaadin/application/views/NetCashflowForecastView.java
@@ -26,7 +26,6 @@ import org.vaadin.application.MainLayout;
 import org.vaadin.application.service.ExpenseService;
 import org.vaadin.application.service.IncomeService;
 import org.vaadin.application.service.SessionService;
-import org.vaadin.application.service.UserService;
 
 @Route(value = "netCashflowForecast", layout = MainLayout.class)
 public class NetCashflowForecastView extends VerticalLayout {
@@ -78,6 +77,7 @@ public class NetCashflowForecastView extends VerticalLayout {
         new ComboBox<>(
             "Select Number of Previous Months for Expense Prediction", Arrays.asList(3, 6, 12));
         monthsComboBox.setValue(previousMonths);
+        monthsComboBox.setWidth("40%");
         monthsComboBox.addValueChangeListener(e -> {
           previousMonths = e.getValue();
           updateExpenseChart();


### PR DESCRIPTION
# Cashflow Forecasting Missing Link

## Related Issue
Closes #82 

## Description
This pull request restores the missing cashflow forecasting link in the navigation bar. The link was unintentionally removed during a previous merge conflict resolution. This change ensures that users can navigate to the cashflow forecasting view.

## Testing
1. Login to the application and observe the presence of the Cashflow Forecasting link on the navigation bar.
2. Click the Cashflow Forecasting link and confirm that it correctly navigates to the NetCashflowForecastView.
- Verified that all existing navigation links function as expected.

## Additional Context
This fix addresses a bug caused by a merge conflict. No new functionality was added, only a correction to restore existing functionality. 
If you don't feel like adding income and expense data to view the graphs you can use my login
Username: V
Password: Meowy